### PR TITLE
Add LocalStack license requirement and standardize setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,19 @@ $(VENV_ACTIVATE):
 
 venv: $(VENV_ACTIVATE)    ## Create a new (empty) virtual environment
 
-start:
-	$(LOCAL_ENV) docker compose up --build --detach --wait
+start:		## Start LocalStack
+	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
+	$(LOCAL_ENV) LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) docker compose up --build --detach --wait
+
+stop:		## Stop LocalStack
+	docker compose down
+
+ready:		## Wait until LocalStack is ready
+	@echo Waiting on the LocalStack container...
+	@localstack wait -t 30 && echo LocalStack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+
+logs:		## Save the logs in a separate file
+	@localstack logs > logs.txt
 
 install: venv
 	$(VENV_RUN); $(PIP_CMD) install -r requirements.txt
@@ -56,3 +67,5 @@ run:
 
 run-aws:
 	$(VENV_RUN); $(CLOUD_ENV) python run.py
+
+.PHONY: usage venv start stop ready logs install deploy deploy-aws destroy destroy-aws run run-aws

--- a/README.md
+++ b/README.md
@@ -8,20 +8,22 @@ This scenario demonstrates how to use Database Migration Service (DMS) to create
 
 ## Pre-requisites
 
--   [LocalStack Auth Token](https://docs.localstack.cloud/getting-started/auth-token/)
+-   A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
 -   [Python 3.10](https://www.python.org/downloads/) & `pip`
 -   [Docker Compose](https://docs.docker.com/compose/install/)
 -   [CDK](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/)  with the  [`cdklocal`](https://github.com/localstack/aws-cdk-local) wrapper.
 
-  
-Start LocalStack Pro with the `LOCALSTACK_AUTH_TOKEN`  pre-configured:
+## Start LocalStack
+
+Start LocalStack with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
 
 ```bash
 export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
-docker-compose up
+make start
+make ready
 ```
 
-The Docker Compose file will start LocalStack Pro container and a Postgres container. The Postgres container will be used to showcase how to reach a database external to LocalStack.
+The Docker Compose file will start LocalStack container and a Postgres container. The Postgres container will be used to showcase how to reach a database external to LocalStack.
 
 ## Instructions
 


### PR DESCRIPTION
## Summary

- Add license requirement bullet to Pre-requisites section in README
- Add auth guard to `start` target, add `stop`, `ready`, `logs` targets to Makefile
- Update README Start LocalStack section to use `make start` / `make ready` pattern
- Upgrade `actions/checkout` and `setup-node` to v4
